### PR TITLE
Fix duplication with item holder and powered stand

### DIFF
--- a/nodeboxes.lua
+++ b/nodeboxes.lua
@@ -606,8 +606,11 @@ minetest.register_node("scifi_nodes:powered_stand", {
 	groups = {cracky=1, oddly_breakable_by_hand=1},
 	on_rightclick = function(pos, node, clicker, item, _)
 		local wield_item = clicker:get_wielded_item():get_name()
-		item:take_item()
-		minetest.add_item({x=pos.x, y=pos.y+1, z=pos.z}, wield_item)
+		local taken = item:take_item()
+		if taken and not taken:is_empty() then
+			minetest.add_item({x=pos.x, y=pos.y+1, z=pos.z}, wield_item)
+			return item
+		end
 	end,
 })
 
@@ -1067,8 +1070,11 @@ minetest.register_node("scifi_nodes:itemholder", {
 		if name == meta:get_string("owner") or
 				minetest.check_player_privs(name, "protection_bypass") then
 			local wield_item = clicker:get_wielded_item():get_name()
-			item:take_item()
-			minetest.add_item(pos, wield_item)
+			local taken = item:take_item()
+			if taken and not taken:is_empty() then
+				minetest.add_item(pos, wield_item)
+				return item
+			end
 		end
 	end,
 	can_dig = function(pos,player)


### PR DESCRIPTION
The item holder and powered stand could be used to duplicate buckets, cans from technic, and mob eggs from mobs_redo, as these items were added to the nodes without being removed from the player's inventory.