### PR TITLE
Allow sunlight under dark glass

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -822,7 +822,7 @@ minetest.register_node("scifi_nodes:blumetstr", {
 minetest.register_node("scifi_nodes:glass", {
 	description = "dark glass",
 	drawtype = "glasslike",
-	sunlight_propagates = false,
+	sunlight_propagates = true,
 	tiles = {
 		"scifi_nodes_glass.png"
 	},


### PR DESCRIPTION
This lets sunlight continue to propagate indefinitely under dark glass, like with obsidian glass.