### PR TITLE
Preserve the metadata of items in the itemholder by converting to string instead of taking name

### DIFF
--- a/nodeboxes.lua
+++ b/nodeboxes.lua
@@ -1080,10 +1080,9 @@ minetest.register_node("scifi_nodes:itemholder", {
 		local meta = minetest.get_meta(pos)
 		if name == meta:get_string("owner") or
 				minetest.check_player_privs(name, "protection_bypass") then
-			local wield_item = clicker:get_wielded_item():get_name()
 			local taken = item:take_item()
 			if taken and not taken:is_empty() then
-				minetest.add_item(pos, wield_item)
+				minetest.add_item(pos, taken:to_string())
 				return item
 			end
 		end


### PR DESCRIPTION
Fixes BLS issue 201 https://github.com/BlockySurvival/issue-tracker/issues/201

Item metadata is preserved by converting to string as opposed to just retrieving the name. The simplest example of why this is an issue is damaged tools: you can place a damaged tool in the item holder, and when you retrieve it all damage will be gone.

This change uses the full string instead, which includes serialised metadata, preserving it when the item is retrieved.

Another way to test this is with a written book.