### PR TITLE
add script and workflow to generate static info-page with mtinfo

### DIFF
--- a/.github/workflows/mtinfo.yml
+++ b/.github/workflows/mtinfo.yml
@@ -1,0 +1,21 @@
+name: mtinfo
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: generate
+      run: ./generate-mtinfo.sh
+
+    - name: deploy
+      if: github.ref == 'refs/heads/master'
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./output

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# generated sources
+output

--- a/generate-mtinfo.sh
+++ b/generate-mtinfo.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# prepare config
+CONFIG=/tmp/scifi_nodes_minetest.conf
+echo "mtinfo.autoshutdown = true" > ${CONFIG}
+echo "moreblocks.stairsplus_in_creative_inventory = false" >> ${CONFIG}
+
+# prepare dependent mods
+WORLDMODS_DIR=/tmp/scifi_nodes_worldmods
+git clone --depth=1 https://gitlab.com/VanessaE/unifieddyes.git ${WORLDMODS_DIR}/unifieddyes
+git clone --depth=1 https://gitlab.com/VanessaE/basic_materials.git ${WORLDMODS_DIR}/basic_materials
+git clone --depth=1 https://github.com/minetest-mods/mesecons.git ${WORLDMODS_DIR}/mesecons
+git clone --depth=1 https://github.com/minetest-mods/moreblocks.git ${WORLDMODS_DIR}/moreblocks
+git clone --depth=1 https://github.com/BuckarooBanzay/mtinfo.git ${WORLDMODS_DIR}/mtinfo
+cp . ${WORLDMODS_DIR}/scifi_nodes -R
+
+# start container with mtinfo
+docker run --rm -i \
+	--user root \
+	-v ${CONFIG}:/etc/minetest/minetest.conf:ro \
+	-v ${WORLDMODS_DIR}/:/root/.minetest/worlds/world/worldmods \
+	-v $(pwd)/output:/root/.minetest/worlds/world/mtinfo \
+	registry.gitlab.com/minetest/minetest/server:5.4.0
+
+test -f $(pwd)/output/index.html || exit 1
+test -f $(pwd)/output/data/items.js || exit 1
+test -d $(pwd)/output/textures || exit 1


### PR DESCRIPTION
This adds a workflow and script to generate a static info page with the `mtinfo` mod.
The static page contains the node-previews as well as some additional infos like recipes, abm, etc.
It is still in a rough state but pretty usable right now.

* Mod: https://github.com/BuckarooBanzay/mtinfo/
* Example: https://mt-mods.github.io/technic/#/mods/technic/items

Leaving this here as draft as it needs the "github-pages" setting enabled in the repository-settings and i think i'll add some more polish to the `mtinfo` mod.