### PR TITLE
Fix palm scanners: Exit minetest.after callback if node no longer exists

### DIFF
--- a/palm_scanner.lua
+++ b/palm_scanner.lua
@@ -22,6 +22,8 @@ local function activate_palm_scanner(pos, node, player)
 
 	-- check protection
 	minetest.after(2, function()
+		if minetest.get_node(pos).name ~= node.name then return end
+
 		if minetest.is_protected(pos, name or "") then
 			-- clicker has no access to area
 			minetest.chat_send_player(name, "Access denied !")
@@ -36,6 +38,7 @@ local function activate_palm_scanner(pos, node, player)
 
 		-- reset state
 		minetest.after(1, function()
+			if minetest.get_node(pos).name ~= node.name then return end
 			node.name = "scifi_nodes:palm_scanner_off"
 			minetest.swap_node(pos, node)
 			mesecon.receptor_off(pos, scifi_nodes.get_switch_rules(node.param2))


### PR DESCRIPTION
Fixes https://github.com/BlockySurvival/issue-tracker/issues/210

Palm scanners can be duplicated if you remove them while they are in the checking state.
If you:

- Place the palm scanner
- Get a fast pick axe in your hand (tested with a diamond pick)
- Right-click the palm scanner to start scanning
- Quickly remove the palm scanner while it is scanning
- Once the scanner is done checking it will appear again, duplicating the item

To fix this I have exited the `minetest.after` callbacks if the node is not the expected node, this will stop it confirming your palm and re-placing the normal-state palm scanner if you remove it mid-scan