### PR TITLE
register a subset of the nodes in the pkarcs mod

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -20,6 +20,7 @@ read_globals = {
 	"screwdriver",
 	"minetest",
 	"mesecon",
-	"unifieddyes"
+	"unifieddyes",
+	"pkarcs"
 
 }

--- a/init.lua
+++ b/init.lua
@@ -31,3 +31,8 @@ dofile(MP.."/digicode.lua")
 dofile(MP.."/models.lua")
 dofile(MP.."/octagon_panes.lua")
 dofile(MP.."/crafts.lua")
+
+if minetest.get_modpath("pkarcs") then
+	-- register some nodes in the pkarcs mod
+	dofile(MP.."/pkarcs.lua")
+end

--- a/mod.conf
+++ b/mod.conf
@@ -11,5 +11,6 @@ mesecons_torch,
 mesecons_receiver,
 basic_materials,
 dye,
-unifieddyes
+unifieddyes,
+pkarcs
 """

--- a/pkarcs.lua
+++ b/pkarcs.lua
@@ -1,0 +1,4 @@
+pkarcs.register_node("scifi_nodes:whitetile")
+pkarcs.register_node("scifi_nodes:whiteoct")
+pkarcs.register_node("scifi_nodes:white")
+pkarcs.register_node("scifi_nodes:lighttop")


### PR DESCRIPTION
This PR registers a subset of the scifi_nodes (some plastic and the metal node) in the `pkarcs` mod (https://github.com/TumeniNodes/pkarcs)
Additional dependency is optional of course

An example of what is possible/how it looks like:
![screenshot_20211002_175645](https://user-images.githubusercontent.com/39065740/135723853-e037c033-ae75-4d59-a40f-5c197874af65.png)

