### PR TITLE
Set more fitting node sounds

### DIFF
--- a/builder.lua
+++ b/builder.lua
@@ -105,5 +105,6 @@ minetest.register_node("scifi_nodes:builder", {
 	end,
 	paramtype = "light",
 	paramtype2 = "facedir",
-	groups = {cracky=1, oddly_breakable_by_hand=1}
+	groups = {cracky=1, oddly_breakable_by_hand=1},
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 })

--- a/digicode.lua
+++ b/digicode.lua
@@ -129,7 +129,7 @@ minetest.register_node("scifi_nodes:digicode_on", {
 		}
 	},
 	on_timer = toggle_digicode,
-	sounds = scifi_nodes.node_sound_glass_defaults(),
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 })
 
 minetest.register_node("scifi_nodes:digicode_off", {
@@ -152,7 +152,7 @@ minetest.register_node("scifi_nodes:digicode_off", {
 	},
 	after_place_node = set_owner,
 	on_rightclick = show_digicode_formspec,
-	sounds = scifi_nodes.node_sound_glass_defaults(),
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 })
 
 minetest.register_craft({

--- a/doors.lua
+++ b/doors.lua
@@ -257,6 +257,7 @@ for _, current_door in ipairs(doors) do
 		on_place = onplace,
 		after_destruct = afterdestruct,
 		on_rightclick = doors_rightclick,
+		sounds = scifi_nodes.node_sound_metal_defaults(),
 	})
 
 	minetest.register_node(closed_top, {
@@ -285,6 +286,7 @@ for _, current_door in ipairs(doors) do
 			}
 		},
 		can_dig = nodig,
+		sounds = scifi_nodes.node_sound_metal_defaults(),
 	})
 
 	minetest.register_node(opened, {
@@ -316,6 +318,7 @@ for _, current_door in ipairs(doors) do
 		after_place_node = afterplace,
 		after_destruct = afterdestruct,
 		on_timer = ontimer,
+		sounds = scifi_nodes.node_sound_metal_defaults(),
 	})
 
 	minetest.register_node(opened_top, {
@@ -344,5 +347,6 @@ for _, current_door in ipairs(doors) do
 			}
 		},
 		can_dig = nodig,
+		sounds = scifi_nodes.node_sound_metal_defaults(),
 	})
 end     -- end of doors table browsing

--- a/models.lua
+++ b/models.lua
@@ -2,7 +2,13 @@
 --Copyright (c) 2011-2015 Calinou and contributors.
 --Licensed under the zlib license.
 
-function scifi_nodes.register_slope(name, desc, texture, light)
+function scifi_nodes.register_slope(name, desc, texture, light, soundtype)
+local sounds
+if soundtype == "stone" then
+	sounds = scifi_nodes.node_sound_stone_defaults()
+else
+	sounds = scifi_nodes.node_sound_metal_defaults()
+end
 minetest.register_node("scifi_nodes:slope_"..name, {
 	description = desc.." Slope",
 	sunlight_propagates = false,
@@ -32,14 +38,15 @@ minetest.register_node("scifi_nodes:slope_"..name, {
 	use_texture_alpha = "clip",
 	light_source = light,
 	groups = {cracky=1, dig_generic = 3},
-	on_place = minetest.rotate_node
+	on_place = minetest.rotate_node,
+	sounds = sounds,
 })
 end
 
 -- register some blocks in stairsplus if available (part of moreblocks)
-scifi_nodes.register_slope("white2", "Plastic", {"scifi_nodes_white2.png",}, 0)
-scifi_nodes.register_slope("super_white", "Super Plastic", {"scifi_nodes_super_white.png",}, 11)
-scifi_nodes.register_slope("ultra_white", "Super Plastic", {"scifi_nodes_ultra_white.png",}, minetest.LIGHT_MAX)
+scifi_nodes.register_slope("white2", "Plastic", {"scifi_nodes_white2.png",}, 0, "stone")
+scifi_nodes.register_slope("super_white", "Super Plastic", {"scifi_nodes_super_white.png",}, 11, "stone")
+scifi_nodes.register_slope("ultra_white", "Super Plastic", {"scifi_nodes_ultra_white.png",}, minetest.LIGHT_MAX, "stone")
 scifi_nodes.register_slope("black", "Black", {"scifi_nodes_black.png",}, 0)
 scifi_nodes.register_slope("white", "White", {"scifi_nodes_white.png",}, 0)
 scifi_nodes.register_slope("grey", "Grey", {"scifi_nodes_grey.png",}, 0)
@@ -73,7 +80,7 @@ node.types = {
 	{"blue",      "blue lines"},
 	{"holes",       "metal with holes"},
 	{"white2",      "plastic",},
-	{"super_white",      "Super Plastic", 11},
+	{"super_white",      "Super Plastic", 11, "stone"},
 	{"ultra_white",      "Ultra Plastic", minetest.LIGHT_MAX},
 --	{"engine",      "engine",          "engine"},
 	{"wall",      "metal wall"},
@@ -149,8 +156,8 @@ node.types = {
 	{"pplwll4",      "Purple wall4"},
 	{"pplblk",      "Purple tile"},
 	{"purple",      "Purple node"},
-	{"rock",      "Moonstone"},
-	{"rock2",      "Moonstone2"},
+	{"rock",      "Moonstone", nil, "stone"},
+	{"rock2",      "Moonstone2", nil, "stone"},
 	{"blackvnt",      "Black vent"},
 	{"blackplate",      "Black plate"},
 }
@@ -158,6 +165,13 @@ node.types = {
 if minetest.global_exists("stairsplus") then
 	for _, row in ipairs(node.types) do
 		local name = row[1]
+		local soundtype = row[4]
+		local sounds
+		if soundtype == "stone" then
+			sounds = scifi_nodes.node_sound_stone_defaults()
+		else
+			sounds = scifi_nodes.node_sound_metal_defaults()
+		end
 
 		-- Node Definition
 		stairsplus:register_all("scifi_nodes", name, "scifi_nodes:"..name, {
@@ -168,6 +182,7 @@ if minetest.global_exists("stairsplus") then
 			paramtype = "light",
 			paramtype2 = "facedir",
 			light_source = row[3],
+			sounds = sounds,
 		})
 	end
 end

--- a/nodeboxes.lua
+++ b/nodeboxes.lua
@@ -122,8 +122,8 @@ minetest.register_node("scifi_nodes:egg", {
 			{-0.125, 0.75, -0.125, 0.125, 0.8125, 0.125}, -- NodeBox8
 			{-0.375, -0.3125, -0.4375, 0.375, 0.3125, 0.4375}, -- NodeBox9
 		},
-	sounds = scifi_nodes.node_sound_wood_defaults()
-	}
+	},
+	sounds = scifi_nodes.node_sound_wood_defaults(),
 })
 
 if minetest.get_modpath("scifi_mobs") then
@@ -264,8 +264,8 @@ minetest.register_node("scifi_nodes:pad", {
 			{-0.875, -0.5, -0.8125, 0.8125, -0.375, 0.8125}, -- NodeBox3
 			{-0.8125, -0.5, -0.75, 0.75, -0.3125, 0.75}, -- NodeBox4
 		},
-	sounds = scifi_nodes.node_sound_wood_defaults()
-	}
+	},
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 })
 
 minetest.register_node("scifi_nodes:pplwndw", {
@@ -320,7 +320,8 @@ minetest.register_node("scifi_nodes:gloshroom", {
 			{-0.1875, 0.125, -0.1875, 0.1875, 0.1875, 0.1875}, -- NodeBox5
 			{-0.375, -0.0625, -0.4375, 0.375, 0, 0.4375}, -- NodeBox6
 		}
-	}
+	},
+	sounds = scifi_nodes.node_sound_plant_defaults(),
 })
 
 minetest.register_node("scifi_nodes:pot_lid", {
@@ -410,7 +411,9 @@ minetest.register_node("scifi_nodes:pot", {
 	},
 	on_rightclick = toggle_lid,
 	on_destruct = remove_lid,
-	sounds = scifi_nodes.node_sound_metal_defaults(),
+	sounds = scifi_nodes.node_sound_metal_defaults({
+		footstep = scifi_nodes.node_sound_dirt_defaults().footstep,
+	}),
 })
 
 minetest.register_node("scifi_nodes:pot2", {
@@ -442,7 +445,9 @@ minetest.register_node("scifi_nodes:pot2", {
 	},
 	on_rightclick = toggle_lid,
 	on_destruct = remove_lid,
-	sounds = scifi_nodes.node_sound_metal_defaults(),
+	sounds = scifi_nodes.node_sound_metal_defaults({
+		footstep = scifi_nodes.node_sound_dirt_defaults().footstep,
+	}),
 })
 
 minetest.register_node("scifi_nodes:lightbar", {
@@ -523,8 +528,8 @@ minetest.register_node("scifi_nodes:ladder", {
 			{0.3125, -0.5, 0.0625, 0.4375, -0.375, 0.1875}, -- NodeBox25
 			{0.3125, -0.5, -0.1875, 0.4375, -0.375, -0.0625}, -- NodeBox26
 		},
-	sounds = scifi_nodes.node_sound_metal_defaults()
 	},
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 	paramtype2 = "wallmounted",
 	walkable = false,
 	climbable = true,
@@ -636,6 +641,7 @@ minetest.register_node("scifi_nodes:powered_stand", {
 			return item
 		end
 	end,
+	sounds = scifi_nodes.node_sound_wood_defaults()
 })
 
 minetest.register_node("scifi_nodes:cover", {
@@ -658,7 +664,7 @@ minetest.register_node("scifi_nodes:cover", {
 			{-0.3125, -0.375, -0.3125, 0.3125, -0.3125, 0.3125}, -- NodeBox6
 		}
 	},
-	sounds = scifi_nodes.node_sound_wood_defaults(),
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 	groups = {cracky=1, oddly_breakable_by_hand=1}
 })
 
@@ -682,7 +688,8 @@ minetest.register_node("scifi_nodes:computer", {
 			{-0.4375, -0.5, -0.5, 0.0625, 0.5, 0.5}, -- NodeBox1
 		}
 	},
-	groups = {cracky=1, oddly_breakable_by_hand=1}
+	groups = {cracky=1, oddly_breakable_by_hand=1},
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 })
 
 minetest.register_node("scifi_nodes:keysmonitor", {
@@ -708,7 +715,8 @@ minetest.register_node("scifi_nodes:keysmonitor", {
 			{-0.5, -0.3125, 0.25, 0.5, 0.5, 0.375}, -- NodeBox4
 		}
 	},
-	groups = {cracky=1, oddly_breakable_by_hand=1}
+	groups = {cracky=1, oddly_breakable_by_hand=1},
+	sounds = scifi_nodes.node_sound_defaults(),
 })
 
 minetest.register_node("scifi_nodes:microscope", {
@@ -735,7 +743,8 @@ minetest.register_node("scifi_nodes:microscope", {
 			{-0.125, -0.25, -0.125, 0.125, -0.1875, 0.1875}, -- NodeBox5
 		}
 	},
-	groups = {cracky=1, oddly_breakable_by_hand=1}
+	groups = {cracky=1, oddly_breakable_by_hand=1},
+	sounds = scifi_nodes.node_sound_defaults(),
 })
 
 minetest.register_node("scifi_nodes:table", {
@@ -792,6 +801,7 @@ minetest.register_node("scifi_nodes:laptop_open", {
 	on_rightclick = function(pos, node, clicker, item, _)
 			minetest.set_node(pos, {name="scifi_nodes:laptop_closed", param2=node.param2})
 	end,
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 })
 
 minetest.register_node("scifi_nodes:laptop_closed", {
@@ -818,6 +828,7 @@ minetest.register_node("scifi_nodes:laptop_closed", {
 	on_rightclick = function(pos, node, clicker, item, _)
 			minetest.set_node(pos, {name="scifi_nodes:laptop_open", param2=node.param2})
 	end,
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 })
 
 minetest.register_node("scifi_nodes:pipen", {
@@ -848,7 +859,8 @@ minetest.register_node("scifi_nodes:pipen", {
 		}
 	},
 	groups = {cracky=1, dig_generic = 3},
-	on_place = minetest.rotate_node
+	on_place = minetest.rotate_node,
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 })
 
 minetest.register_node("scifi_nodes:windowcorner", {
@@ -1115,6 +1127,7 @@ minetest.register_node("scifi_nodes:itemholder", {
 			minetest.add_item(pos, meta:get_string("item"))
 		end
 	end,
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 })
 
 minetest.register_node("scifi_nodes:glassscreen", {
@@ -1172,7 +1185,8 @@ minetest.register_node("scifi_nodes:widescreen", {
 			{-0.5, 0.25, 0.375, 0.5, 0.3125, 0.5},         -- NodeBox7
 		}
 	},
-	groups = {cracky=1, oddly_breakable_by_hand=1}
+	groups = {cracky=1, oddly_breakable_by_hand=1},
+	sounds = scifi_nodes.node_sound_defaults(),
 })
 
 minetest.register_node("scifi_nodes:tallscreen", {
@@ -1202,7 +1216,8 @@ minetest.register_node("scifi_nodes:tallscreen", {
 			{0.25, -0.5, 0.375, 0.3125, 0.5, 0.5}, -- NodeBox7
 		}
 	},
-	groups = {cracky=1, oddly_breakable_by_hand=1}
+	groups = {cracky=1, oddly_breakable_by_hand=1},
+	sounds = scifi_nodes.node_sound_defaults(),
 })
 
 -- https://forum.minetest.net/viewtopic.php?f=10&t=13125&p=261481#p261481

--- a/nodes.lua
+++ b/nodes.lua
@@ -8,7 +8,10 @@ if minetest.get_modpath("default") then
 			{name = "default_dirt.png^(default_grass_side.png^[colorize:cyan:80)",
 				tileable_vertical = false}},
 		light_source = 2,
-		groups = {crumbly=1, oddly_breakable_by_hand=1, soil=1}
+		groups = {crumbly=1, oddly_breakable_by_hand=1, soil=1},
+		sounds = scifi_nodes.node_sound_dirt_defaults({
+			footstep = scifi_nodes.node_sound_plant_defaults().footstep,
+		}),
 	})
 end
 
@@ -25,7 +28,8 @@ minetest.register_node("scifi_nodes:light", {
 	},
 	light_source = 10,
 	paramtype = "light",
-	groups = {cracky=1, dig_generic = 3}
+	groups = {cracky=1, dig_generic = 3},
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 })
 
 minetest.register_node("scifi_nodes:rfloor", {
@@ -168,7 +172,7 @@ minetest.register_node("scifi_nodes:discs", {
 	},
 	paramtype = "light",
 	groups = {cracky=1, dig_generic = 3},
-	sounds = scifi_nodes.node_sound_glass_defaults()
+	sounds = scifi_nodes.node_sound_metal_defaults()
 })
 
 minetest.register_node("scifi_nodes:disc", {
@@ -181,7 +185,8 @@ minetest.register_node("scifi_nodes:disc", {
 	inventory_image = "scifi_nodes_disc.png",
 	wield_image = "scifi_nodes_disc.png",
 	paramtype = "light",
-	groups = {cracky=1, dig_generic = 3}
+	groups = {cracky=1, dig_generic = 3},
+	sounds = scifi_nodes.node_sound_defaults(),
 })
 
 minetest.register_node("scifi_nodes:greenbar_animated", {
@@ -224,7 +229,7 @@ minetest.register_node("scifi_nodes:black_lights", {
 	}},
 	paramtype = "light",
 	groups = {cracky=1, dig_generic = 3},
-	sounds = scifi_nodes.node_sound_glass_defaults()
+	sounds = scifi_nodes.node_sound_metal_defaults()
 })
 
 minetest.register_node("scifi_nodes:black_screen", {
@@ -237,7 +242,7 @@ minetest.register_node("scifi_nodes:black_screen", {
 	paramtype = "light",
 	groups = {cracky=1, dig_generic = 3},
 	light_source = 1,
-	sounds = scifi_nodes.node_sound_stone_defaults()
+	sounds = scifi_nodes.node_sound_metal_defaults()
 })
 
 minetest.register_node("scifi_nodes:screen", {
@@ -282,7 +287,7 @@ minetest.register_node("scifi_nodes:white_pad", {
 	paramtype = "light",
 	paramtype2 = "facedir",
 	groups = {cracky=1, dig_generic = 3},
-	sounds = scifi_nodes.node_sound_glass_defaults()
+	sounds = scifi_nodes.node_sound_metal_defaults()
 })
 
 minetest.register_node("scifi_nodes:white_base", {
@@ -428,7 +433,7 @@ minetest.register_node("scifi_nodes:junk", {
 	tiles = {
 		"scifi_nodes_junk.png"
 	},
-	groups = {snappy=1, oddly_breakable_by_hand=1, liquid=3, dig_immediate=1}
+	groups = {snappy=1, oddly_breakable_by_hand=1, liquid=3, dig_immediate=1},
 })
 
 
@@ -471,7 +476,7 @@ minetest.register_node("scifi_nodes:blklt2", {
 	light_source = 10,
 	paramtype = "light",
 	groups = {cracky=1, dig_generic = 3},
-	sounds = scifi_nodes.node_sound_glass_defaults()
+	sounds = scifi_nodes.node_sound_metal_defaults()
 })
 
 minetest.register_node("scifi_nodes:blumetstr", {
@@ -483,7 +488,7 @@ minetest.register_node("scifi_nodes:blumetstr", {
 	light_source = 10,
 	paramtype = "light",
 	groups = {cracky=1, dig_generic = 3},
-	sounds = scifi_nodes.node_sound_glass_defaults()
+	sounds = scifi_nodes.node_sound_metal_defaults()
 })
 
 minetest.register_node("scifi_nodes:glass", {
@@ -508,7 +513,7 @@ minetest.register_node("scifi_nodes:whtlightbnd", {
 	light_source = 10,
 	paramtype = "light",
 	groups = {cracky=1, dig_generic = 3},
-	sounds = scifi_nodes.node_sound_glass_defaults()
+	sounds = scifi_nodes.node_sound_metal_defaults()
 })
 
 --edited wool code (Copyright (C) 2012 celeron55, Perttu Ahola <celeron55@gmail.com>)
@@ -519,15 +524,15 @@ minetest.register_node("scifi_nodes:whtlightbnd", {
 -- colors available. When crafting, the last recipes will be checked first.
 --add new block using texture name(without "scifi_nodes_" prefix) then the description, and then the name of the block
 local nodetypes = {
-	-- { name, description, shortname?, light, colorable }
+	-- { name, description, shortname?, light, colorable, sounds }
 	{"blue",      "blue lines",        "blue"},
 	{"holes",       "metal with holes","holes"},
-	{"white2",      "plastic",         "white2", 0, true},
-    {"super_white",      "Super Plastic",         "super_white", 11},
-    {"ultra_white",      "Ultra Plastic",         "ultra_white", minetest.LIGHT_MAX},
+	{"white2",      "plastic",         "white2", 0, true, "stone"},
+    {"super_white",      "Super Plastic",         "super_white", 11, nil, "stone"},
+    {"ultra_white",      "Ultra Plastic",         "ultra_white", minetest.LIGHT_MAX, nil, "stone"},
 	{"engine",      "engine",          "engine"},
 	{"wall",      "metal wall",        "wall"},
-	{"white",      "plastic wall",     "white", 0, true},
+	{"white",      "plastic wall",     "white", 0, true, "stone"},
 	{"stripes2top",     "dirty metal block","metal2"},
 	{"rough",      "rough metal",      "rough"},
 	{"lighttop",      "metal block",      "metal"},
@@ -572,8 +577,8 @@ local nodetypes = {
 	{"greybars",      "grey bars",       "grybrs"},
 	{"greydots",      "grey wall dots",       "grydts"},
 	{"greygreenbar",      "gray power pipe",       "grygrnbr", 10},
-	{"octofloor",      "Doom floor",       "octofloor"},
-	{"octofloor2",      "Brown Doom floor",       "octofloor2"},
+	{"octofloor",      "Doom floor",       "octofloor", nil, nil, "stone"},
+	{"octofloor2",      "Brown Doom floor",       "octofloor2", nil, nil, "stone"},
 	{"doomwall1",      "Doom wall 1",       "doomwall1"},
 	{"doomwall2",      "Doom wall 2",       "doomwall2"},
 	{"doomwall3",      "Doom wall 3",       "doomwall3"},
@@ -599,8 +604,8 @@ local nodetypes = {
 	{"pplwll4",      "Purple wall4", "", 0},
 	{"pplblk",      "Purple tile", "", 0},
 	{"purple",      "Purple node", "", 0},
-	{"rock",      "Moonstone", "", 0},
-	{"rock2",      "Moonstone2", "", 0},
+	{"rock",      "Moonstone", "", 0, nil, "stone"},
+	{"rock2",      "Moonstone2", "", 0, nil, "stone"},
 	{"blackvnt",      "Black vent", "", 0},
 	{"blackplate",      "Black plate", "", 0},
 }
@@ -612,6 +617,14 @@ for _, row in ipairs(nodetypes) do
 	local desc = row[2]
 	local light = row[4]
 	local is_colorable = row[5]
+	local soundtype = row[6]
+
+	local sounds
+	if soundtype == "stone" then
+		sounds = scifi_nodes.node_sound_stone_defaults()
+	else
+		sounds = scifi_nodes.node_sound_metal_defaults()
+	end
 
 	-- Node Definition
 	local node_def = {
@@ -621,7 +634,7 @@ for _, row in ipairs(nodetypes) do
 		paramtype = "light",
 		paramtype2 = "facedir",
 		light_source = light,
-		sounds = scifi_nodes.node_sound_glass_defaults()
+		sounds = sounds,
 	}
 
 	if is_colorable and has_unifieddyes_mod then

--- a/palm_scanner.lua
+++ b/palm_scanner.lua
@@ -65,7 +65,7 @@ minetest.register_node("scifi_nodes:palm_scanner_off", {
 		}
 	},
 	on_rightclick = (has_mesecons and activate_palm_scanner),
-	sounds = scifi_nodes.node_sound_glass_defaults(),
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 })
 
 minetest.register_node("scifi_nodes:palm_scanner_checking", {
@@ -83,7 +83,7 @@ minetest.register_node("scifi_nodes:palm_scanner_checking", {
 	paramtype2 = "wallmounted",
 	groups = {cracky=1, oddly_breakable_by_hand=1, not_in_creative_inventory=1, mesecon_needs_receiver = 1},
 	drop = "scifi_nodes:palm_scanner_off",
-	sounds = scifi_nodes.node_sound_glass_defaults()
+	sounds = scifi_nodes.node_sound_metal_defaults()
 })
 
 minetest.register_node("scifi_nodes:palm_scanner_on", {
@@ -106,7 +106,7 @@ minetest.register_node("scifi_nodes:palm_scanner_on", {
 			state = (has_mesecons and mesecon.state.on)
 		}
 	},
-	sounds = scifi_nodes.node_sound_glass_defaults(),
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 })
 
 minetest.register_craft({

--- a/plants.lua
+++ b/plants.lua
@@ -43,5 +43,6 @@ for _, row in ipairs(plants) do
 		},
 		is_ground_content = false,
 		light_source = light,
+		sounds = scifi_nodes.node_sound_plant_defaults(),
 	})
 end

--- a/protected_switch.lua
+++ b/protected_switch.lua
@@ -51,7 +51,7 @@ minetest.register_node("scifi_nodes:protected_switch_on", {
 			state = (has_mesecons and mesecon.state.on)
 		}
 	},
-	sounds = scifi_nodes.node_sound_glass_defaults(),
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 	on_rightclick = (has_mesecons and toggle_switch),
 	on_timer = (has_mesecons and toggle_switch)
 })
@@ -78,7 +78,7 @@ minetest.register_node("scifi_nodes:protected_switch_off", {
 			state = (has_mesecons and mesecon.state.off)
 		}
 	},
-	sounds = scifi_nodes.node_sound_glass_defaults(),
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 	on_rightclick = (has_mesecons and toggle_switch)
 })
 

--- a/sounds.lua
+++ b/sounds.lua
@@ -1,29 +1,50 @@
 -- sound definitions
 
-function scifi_nodes.node_sound_wood_defaults()
+function scifi_nodes.node_sound_defaults(param)
     if minetest.get_modpath("default") then
         -- default game
-        return default.node_sound_wood_defaults()
+        return default.node_sound_defaults(param)
     end
 end
 
-function scifi_nodes.node_sound_glass_defaults()
+function scifi_nodes.node_sound_wood_defaults(param)
     if minetest.get_modpath("default") then
         -- default game
-        return default.node_sound_glass_defaults()
+        return default.node_sound_wood_defaults(param)
     end
 end
 
-function scifi_nodes.node_sound_metal_defaults()
+function scifi_nodes.node_sound_glass_defaults(param)
     if minetest.get_modpath("default") then
         -- default game
-        return default.node_sound_metal_defaults()
+        return default.node_sound_glass_defaults(param)
     end
 end
 
-function scifi_nodes.node_sound_stone_defaults()
+function scifi_nodes.node_sound_metal_defaults(param)
     if minetest.get_modpath("default") then
         -- default game
-        return default.node_sound_stone_defaults()
+        return default.node_sound_metal_defaults(param)
+    end
+end
+
+function scifi_nodes.node_sound_stone_defaults(param)
+    if minetest.get_modpath("default") then
+        -- default game
+        return default.node_sound_stone_defaults(param)
+    end
+end
+
+function scifi_nodes.node_sound_dirt_defaults(param)
+    if minetest.get_modpath("default") then
+        -- default game
+        return default.node_sound_dirt_defaults(param)
+    end
+end
+
+function scifi_nodes.node_sound_plant_defaults(param)
+    if minetest.get_modpath("default") then
+        -- default game
+        return default.node_sound_leaves_defaults(param)
     end
 end

--- a/switch.lua
+++ b/switch.lua
@@ -44,7 +44,7 @@ minetest.register_node("scifi_nodes:switch_on", {
 			state = (has_mesecons and mesecon.state.on)
 		}
 	},
-	sounds = scifi_nodes.node_sound_glass_defaults(),
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 	on_rightclick = (has_mesecons and toggle_switch),
 	on_timer = (has_mesecons and toggle_switch)
 })
@@ -71,7 +71,7 @@ minetest.register_node("scifi_nodes:switch_off", {
 			state = (has_mesecons and mesecon.state.off)
 		}
 	},
-	sounds = scifi_nodes.node_sound_glass_defaults(),
+	sounds = scifi_nodes.node_sound_metal_defaults(),
 	on_rightclick = (has_mesecons and toggle_switch)
 })
 


### PR DESCRIPTION
This PR changes the sound of most nodes to make more sense.

Most importantly, metal nodes make metal sounds now.
A few nodes make other sounds when appropriate, e.g. moonstone makes a stone sound.

Fixes #73.