### PR TITLE
register some nodes to the `letters` mod

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -21,6 +21,6 @@ read_globals = {
 	"screwdriver",
 	"minetest",
 	"mesecon",
-	"unifieddyes"
-
+	"unifieddyes",
+	"letters"
 }

--- a/init.lua
+++ b/init.lua
@@ -32,3 +32,8 @@ dofile(MP.."/models.lua")
 dofile(MP.."/octagon_panes.lua")
 dofile(MP.."/forcefield.lua")
 dofile(MP.."/crafts.lua")
+
+if minetest.get_modpath("letters") then
+	-- register letter nodes
+	dofile(MP.."/letters.lua")
+end

--- a/letters.lua
+++ b/letters.lua
@@ -1,0 +1,5 @@
+letters.register_letters("scifi_nodes", "black", "scifi_nodes:black", "Black wall", "scifi_nodes_black.png")
+letters.register_letters("scifi_nodes", "white2", "scifi_nodes:white2", "Plastic", "scifi_nodes_white2.png")
+letters.register_letters("scifi_nodes", "purple", "scifi_nodes:purple", "Purple node", "scifi_nodes_purple.png")
+letters.register_letters("scifi_nodes", "bluemetal", "scifi_nodes:bluemetal", "Blue metal", "scifi_nodes_bluemetal.png")
+letters.register_letters("scifi_nodes", "greenmetal", "scifi_nodes:greenmetal", "Green metal", "scifi_nodes_greenmetal.png")

--- a/mod.conf
+++ b/mod.conf
@@ -11,5 +11,6 @@ mesecons_torch,
 mesecons_receiver,
 basic_materials,
 dye,
-unifieddyes
+unifieddyes,
+letters
 """


### PR DESCRIPTION
This PR adds some nodes (5 with the most prominent colors) to the `letters` mod:

![screenshot_20221207_204222](https://user-images.githubusercontent.com/39065740/206280076-0044b3c0-195b-4774-96ad-0682935ef6bb.png)

As usual: this is an optional dependency