### PR TITLE
add `facedir` param2type to lightbars and liquidpipes

### DIFF
--- a/nodeboxes.lua
+++ b/nodeboxes.lua
@@ -543,6 +543,7 @@ minetest.register_node("scifi_nodes:lightbars", {
 	},
 	drawtype = "nodebox",
 	paramtype = "light",
+	paramtype2 = "facedir",
 	use_texture_alpha = "blend",
 	light_source = minetest.LIGHT_MAX,
 	node_box = {
@@ -569,6 +570,7 @@ tiles = {{
 	drawtype = "nodebox",
 	sunlight_propagates = true,
 	paramtype = "light",
+	paramtype2 = "facedir",
 	node_box = {
 		type = "fixed",
 		fixed = {
@@ -589,6 +591,7 @@ tiles = {
 	drawtype = "nodebox",
 	sunlight_propagates = true,
 	paramtype = "light",
+	paramtype2 = "facedir",
 	node_box = {
 		type = "fixed",
 		fixed = {


### PR DESCRIPTION
Adds `facedir` as param2type to lightbars and liquidpipes to properly rotate them:

![screenshot_20221208_133559](https://user-images.githubusercontent.com/39065740/206447983-d4c37eef-b94b-42d2-9b9c-f250d014e842.png)
