### PR TITLE
Allow Super and Ultra Plastic nodes to be colored

### DIFF
--- a/nodes.json
+++ b/nodes.json
@@ -14,12 +14,14 @@
     },
     "super_white": {
         "description": "Super Plastic",
+        "colorable": true,
         "light": 11,
         "sounds": "stone",
         "texture_name": "white2"
     },
     "ultra_white": {
         "description": "Ultra Plastic",
+        "colorable": true,
         "light": 14,
         "sounds": "stone",
         "texture_name": "white2"


### PR DESCRIPTION
Add `"colorable": true` to Super and Ultra Plastic nodes to enable unified dyes integration.

I don't see any reason not to add colors to them. They are great for glowing pixel art 😄